### PR TITLE
Update int128/go-renovate-config to v1.9.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>int128/renovate-base",
     "github>int128/go-renovate-config#v1.9.0",
     "github>int128/go-renovate-config:go-version#v1.9.0",
-    "helpers:pinGitHubActionDigests",
-  ],
+    "helpers:pinGitHubActionDigests"
+  ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,8 +1,8 @@
 {
   "extends": [
     "github>int128/renovate-base",
-    "github>int128/go-renovate-config#v1.8.0",
-    "github>int128/go-renovate-config:go-directive#v1.7.2",
+    "github>int128/go-renovate-config#v1.9.0",
+    "github>int128/go-renovate-config:go-version#v1.9.0",
     "helpers:pinGitHubActionDigests",
   ],
 }


### PR DESCRIPTION
Updated Renovate configuration to use newer versions of go-renovate-config.